### PR TITLE
Remove "delete storage item" 

### DIFF
--- a/content/sql/delete-storage-item.md
+++ b/content/sql/delete-storage-item.md
@@ -23,6 +23,7 @@ So, in your postgres function, maybe you can do this in case of an exception.
 delete from storage.objects where bucket_id = 'products' and name = 'testing.png'
 ```
 
-If you afraid this only remove the entry from the table, and doesn't actually free up the Storage space, you can check Storage space at Home, before insert image, after insert the image, finally after the query that remove the image.
+If you afraid this only remove the entry from the table, and doesn't actually free up the Storage space, 
+you are correct. This method is **not recommended**, see 
+https://github.com/supabase/supabase/discussions/3124#discussioncomment-1397058 .
 
-You will see the Storage space is the same as before inserting the image.


### PR DESCRIPTION
I almost believed this snippet, only later finding out it actually does not free up storage objects, is not the officially recommended way (via the REST API) and actually does the opposite of what it claims.